### PR TITLE
Kafka 0.10.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ zookeeper:
         ports:
           - '2181:2181'
 kafka:
-        image: 'ches/kafka'
+        image: 'ches/kafka:0.10.1.0'
         links:
           - zookeeper:zookeeper
         ports:

--- a/project.clj
+++ b/project.clj
@@ -4,15 +4,17 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure                           "1.8.0"]
-                 [org.clojure/core.async                        "0.1.346.0-17112a-alpha"]
+                 [org.clojure/core.async                        "0.2.391"]
                  [joda-time                                     "2.8.2"]
                  [com.fasterxml.jackson.core/jackson-databind   "2.6.2"]
                  [amazonica                                     "0.3.33"
                   :exclusions [joda-time
                                com.fasterxml.jackson.core/jackson-core
                                com.fasterxml.jackson.core/jackson-annotations]]
-                 [mastodonc/clj-kafka                           "0.2.6-0.8.2.2"
-                  :exclusions [org.slf4j/slf4j-log4j12]]
+                 [com.taoensso/timbre                           "4.8.0"]
+                 [mastondonc/franzy                             "0.0.3"]
+                 [lbradstreet/franzy-admin                      "0.0.2"
+                  :exclusions [com.taoensso/timbre]]
                  [compojure                                     "1.4.0"]
 
                  [commons-codec                                 "1.10"] ;; FIXME - ring-defaults needs this, but doesn't declare it?
@@ -28,17 +30,9 @@
 
                  [com.stuartsierra/component                    "0.3.0"]
 
-                 [prismatic/schema                              "1.0.1"]
+                 [prismatic/schema                              "1.1.3"]
                  [org.clojure/tools.nrepl                       "0.2.11"]
                  [cider/cider-nrepl                             "0.9.1"]
-
-                 ;; Logging
-                 [org.clojure/tools.logging                     "0.3.1"]
-                 [ch.qos.logback/logback-classic                "1.1.3"]
-                 [org.slf4j/jul-to-slf4j                        "1.7.12"]
-                 [org.slf4j/jcl-over-slf4j                      "1.7.12"]
-                 [org.slf4j/log4j-over-slf4j                    "1.7.12"]
-                 [net.logstash.logback/logstash-logback-encoder "4.6"]
                  [buddy "1.0.0"]
                  [clj-http "2.3.0"]
                  [clj-time "0.12.0"]
@@ -56,7 +50,7 @@
   :profiles {:uberjar {:aot [kixi.eventlog.bootstrap]
                        :main kixi.eventlog.bootstrap
                        :uberjar-name "kixi.eventlog.jar"}
-              :dev {:dependencies [[lein-marginalia "0.8.0"]
+             :dev {:dependencies [[lein-marginalia "0.8.0"]
                                   [org.clojure/tools.namespace "0.2.10"]]
-                    :source-paths ["dev" "src"]
-                    :resource-paths ["dev-resources" "resources"]}})
+                   :source-paths ["dev" "src"]
+                   :resource-paths ["dev-resources" "resources"]}})

--- a/src/kixi/event/producer.clj
+++ b/src/kixi/event/producer.clj
@@ -1,23 +1,75 @@
 (ns kixi.event.producer
-  (:require [clj-kafka.core :as kafka]
-            [clj-kafka.producer :as p]
-            [clojure.tools.logging :as log]
+  (:require [taoensso.timbre :as log]
             [com.stuartsierra.component :as component]
-            [kixi.event.zookeeper :as zk]))
+            [clojure.core.async :as async]
+            [franzy.clients.producer
+             [client :as producer]
+             [defaults :as pd]
+             [protocols :as pp]]
+            [franzy.serialization
+             [deserializers :as deserializers]
+             [serializers :as serializers]]
+            [franzy.admin.zookeeper.defaults :as zk-defaults]
+            [franzy.admin.zookeeper.client :as client]
+            [franzy.admin.cluster :as cluster]))
+
+(defn uuid
+  []
+  (str (java.util.UUID/randomUUID)))
+
+(defn get-broker-list
+  [zk-conf]
+  (let [c (merge (zk-defaults/zk-client-defaults) zk-conf)]
+    (with-open[u (client/make-zk-utils c false)]
+      (cluster/all-brokers u))))
+
+(defn create-producer
+  [in-chan broker-list]
+  (let [key-serializer     (serializers/string-serializer)
+        value-serializer   (serializers/byte-array-serializer)
+        pc                 {:bootstrap.servers broker-list}
+        po                 (pd/make-default-producer-options)]
+    (try
+      (let [producer           (producer/make-producer
+                                pc
+                                key-serializer
+                                value-serializer
+                                po)]
+        (async/go
+          (loop []
+            (let [msg (async/<! in-chan)]
+              (if msg
+                (let [{:keys [topic payload]} msg]
+                  (pp/send-sync! producer topic nil
+                                 (uuid)
+                                 payload
+                                 po)
+                  (recur))
+                (.close producer))))))
+      (catch Exception e
+        (log/error e (str "Producer Exception1, pc=" pc ", po=" po))))))
 
 (defrecord EventProducer []
   component/Lifecycle
   (start [{:keys [zookeeper max-message-size] :as this}]
     (log/info "Starting EventProducer")
     (log/info "  Zookeeper is: " zookeeper)
-    (assoc this ::instance
-           (p/producer {"metadata.broker.list" (zk/broker-list zookeeper)
-                        "serializer.class"     "kafka.serializer.DefaultEncoder"
-                        "partitioner.class"    "kafka.producer.DefaultPartitioner"})))
+    (let [in-chan (async/chan)
+          brokers (get-broker-list {:servers zookeeper})
+          broker-list (clojure.string/join
+                       ","
+                       (map #(->> (get-in % [:endpoints :plaintext])
+                                  ((juxt :host :port))
+                                  (clojure.string/join ":")) brokers))]
+      (assoc this
+             ::instance (create-producer in-chan broker-list)
+             ::chan in-chan)))
   (stop [this]
     (log/info "Stopping EventProducer")
-    (when-let [i (::instance this)] (.close i))
-    (dissoc this ::instance)))
+    (when-let [i (::chan this)] (.close i))
+    (dissoc this
+            ::instance
+            ::chan)))
 
 (defn new-producer
   ([] (->EventProducer))

--- a/src/kixi/event/topic.clj
+++ b/src/kixi/event/topic.clj
@@ -1,37 +1,35 @@
 (ns kixi.event.topic
-  (:require [clj-kafka.consumer.zk :as c]
-            [clj-kafka.core :as kafka]
-            [clj-kafka.producer :as p]
-            [clojure.tools.logging :as log]
-            [com.stuartsierra.component :as component]))
+  (:require [taoensso.timbre :as log]
+            [com.stuartsierra.component :as component]
+            [franzy.admin.zookeeper.defaults :as zk-defaults]
+            [franzy.admin.zookeeper.client :as client]
+            [franzy.admin.topics :as topics]
+            [clojure.core.async :as async]))
 
 
 (defn topic-exists? [zk-client topic-name]
-  (kafka.admin.AdminUtils/topicExists zk-client topic-name))
+  (topics/topic-exists? zk-client topic-name))
 
 (defn- create-topic [zk-client topic-name {:keys [num-partitions replication-factor topic-config] :as opts} ]
   (log/infof "Creating topic %s, config: %s" topic-name (pr-str opts))
-  (kafka.admin.AdminUtils/createTopic zk-client
-                                      topic-name
-                                      num-partitions
-                                      replication-factor
-                                      (kafka/as-properties topic-config)))
+  (topics/create-topic! zk-client
+                        topic-name
+                        num-partitions
+                        replication-factor
+                        topic-config))
 
-(defrecord EventTopics [topic-defs]
+(defrecord EventTopics [topic-defs zookeeper]
   component/Lifecycle
   (start [this]
-    (log/info "Starting EventTopics " (:topic-defs this))
-    (let [zk-connect (get-in (:zookeeper this) [:opts "zookeeper.connect"])
-          zk-client  (org.I0Itec.zkclient.ZkClient. zk-connect
-                                                    10000 ; sessionTimeoutMs
-                                                    10000 ; connectionTimeoutMs
-                                                    kafka.utils.ZKStringSerializer$/MODULE$)]
-      (try 
+    (log/info "Starting EventTopics " topic-defs)
+    (let [zku-conf (merge (zk-defaults/zk-client-defaults) {:servers zookeeper})
+          zk-utils (client/make-zk-utils zku-conf false)]
+      (try
         (doseq [[topic-name opts] (:topic-defs this)
-                :when (not (topic-exists? zk-client topic-name))]
-          (create-topic zk-client topic-name opts))
+                :when (not (topic-exists? zk-utils topic-name))]
+          (create-topic zk-utils topic-name opts))
         (finally
-          (.close zk-client))))
+          (.close zk-utils))))
     this)
   (stop [this]
     (log/info "Stopping EventTopics" (:name this))
@@ -41,8 +39,10 @@
   (log/info "producer:" producer )
   (log/info "topic-name:" topic-name)
   (log/info "event:" event)
-  (p/send-message (:kixi.event.producer/instance producer) (p/message topic-name (.bytes event))))
+  (async/go
+    (async/>! (:kixi.event.producer/chan producer) {:topic topic-name :payload (.bytes event)}))
+  nil)
 
-(defn new-topics 
-  ([topic-defs]
-   (map->EventTopics {:topic-defs topic-defs})))
+(defn new-topics
+  ([& {:as opts}]
+   (map->EventTopics opts)))

--- a/src/kixi/event/zookeeper.clj
+++ b/src/kixi/event/zookeeper.clj
@@ -1,26 +1,26 @@
-(ns kixi.event.zookeeper
-  (:require [clj-kafka.zk]
-            [clojure.tools.logging :as log]
-            [com.stuartsierra.component :as component]
-            [zookeeper :as zk]))
+;; (ns kixi.event.zookeeper
+;;   (:require [clj-kafka.zk]
+;;             [clojure.tools.logging :as log]
+;;             [com.stuartsierra.component :as component]
+;;             [zookeeper :as zk]))
 
-(defrecord ZookeeperClient [opts]
-  component/Lifecycle
-  (start [this]
-    (log/info "Starting ZookeeperClient")
-    this)
-  (stop [this]
-    (log/info "Stopping EventClient")
-    this))
+;; (defrecord ZookeeperClient [opts]
+;;   component/Lifecycle
+;;   (start [this]
+;;     (log/info "Starting ZookeeperClient")
+;;     this)
+;;   (stop [this]
+;;     (log/info "Stopping EventClient")
+;;     this))
 
-(defn connect [{:keys [opts]}]
-  (zk/connect (get opts "zookeeper.connect")))
+;; (defn connect [{:keys [opts]}]
+;;   (zk/connect (get opts "zookeeper.connect")))
 
-(defn close [zkc]
-  (.close zkc))
+;; (defn close [zkc]
+;;   (.close zkc))
 
-(defn broker-list [{:keys [opts]}]
-  (clj-kafka.zk/broker-list (clj-kafka.zk/brokers opts)))
+;; (defn broker-list [{:keys [opts]}]
+;;   (clj-kafka.zk/broker-list (clj-kafka.zk/brokers opts)))
 
-(defn new-zk-client [zk-connect]
-  (->ZookeeperClient {"zookeeper.connect" zk-connect}))
+;; (defn new-zk-client [zk-connect]
+;;   (->ZookeeperClient {"zookeeper.connect" zk-connect}))

--- a/src/kixi/eventlog/api.clj
+++ b/src/kixi/eventlog/api.clj
@@ -1,6 +1,6 @@
 (ns kixi.eventlog.api
   (:require [liberator.core :refer (defresource)]
-            [clojure.tools.logging :as log]))
+            [taoensso.timbre :as log]))
 
 (defn malformed? [ctx]
   (if-let [body (get-in ctx [:request :body])]

--- a/src/kixi/eventlog/authz.clj
+++ b/src/kixi/eventlog/authz.clj
@@ -5,7 +5,7 @@
             [clj-http.client :as client]
             [clj-time.core :as t]
             [clj-time.coerce :as tc]
-            [clojure.tools.logging :as log]
+            [taoensso.timbre :as log]
             [clojure.data.json :as json]
             [ring.middleware.basic-authentication :as basic-auth]))
 

--- a/src/kixi/eventlog/bootstrap.clj
+++ b/src/kixi/eventlog/bootstrap.clj
@@ -1,7 +1,7 @@
 (ns kixi.eventlog.bootstrap
   (:require [cider.nrepl                :refer (cider-nrepl-handler)]
             [clojure.tools.cli          :refer [cli]]
-            [clojure.tools.logging      :as log]
+            [taoensso.timbre      :as log]
             [clojure.tools.nrepl.server :as nrepl-server]
             [com.stuartsierra.component :as component]
             [kixi.eventlog.application  :as kixi])

--- a/src/kixi/eventlog/web_server.clj
+++ b/src/kixi/eventlog/web_server.clj
@@ -1,6 +1,6 @@
 (ns kixi.eventlog.web-server
   (:require [clojure.string :as str]
-            [clojure.tools.logging :as log]
+            [taoensso.timbre :as log]
             [compojure.core :refer [make-route routes POST GET defroutes wrap-routes]]
             [compojure.route :refer [not-found]]
             [com.stuartsierra.component :as component]


### PR DESCRIPTION
Some fairly lofty changes that all revolve around replacing `clj-kafka` with `franzy`, plus a sprinkling of async, updated dependencies and gutting of the archaic logger.